### PR TITLE
hi, cloudwu. 

### DIFF
--- a/buddy.c
+++ b/buddy.c
@@ -79,6 +79,7 @@ _alloc(struct buddy * self, int index, int start, int length, int size) {
 		}
 		return -1;
 	}
+    if (current->left == -1) return -1;
 	if (current->left != 0) {
 		int r = _alloc(self, current->left, start, length/2 , size);
 		if (r>=0)

--- a/buddy.c
+++ b/buddy.c
@@ -79,7 +79,7 @@ _alloc(struct buddy * self, int index, int start, int length, int size) {
 		}
 		return -1;
 	}
-    if (current->left == -1) return -1;
+	if (current->left == -1) return -1;
 	if (current->left != 0) {
 		int r = _alloc(self, current->left, start, length/2 , size);
 		if (r>=0)

--- a/test.c
+++ b/test.c
@@ -32,9 +32,16 @@ main() {
 	test_size(b,m2);
 	int m3 = test_alloc(b,3);
 	test_size(b,m3);
+    int m4 = test_alloc(b,2);
+    test_size(b,m4);
+    int m5 = test_alloc(b,1);
+    test_size(b,m5);
+
 	test_free(b,m3);
 	test_free(b,m1);
+    test_free(b,m5);
 	test_free(b,m2);
+    test_free(b,m4);
 
 	buddy_delete(b);
 	return 0;

--- a/test.c
+++ b/test.c
@@ -32,16 +32,16 @@ main() {
 	test_size(b,m2);
 	int m3 = test_alloc(b,3);
 	test_size(b,m3);
-    int m4 = test_alloc(b,2);
-    test_size(b,m4);
-    int m5 = test_alloc(b,1);
-    test_size(b,m5);
+	int m4 = test_alloc(b,2);
+	test_size(b,m4);
+	int m5 = test_alloc(b,1);
+	test_size(b,m5);
 
 	test_free(b,m3);
 	test_free(b,m1);
-    test_free(b,m5);
+	test_free(b,m5);
 	test_free(b,m2);
-    test_free(b,m4);
+	test_free(b,m4);
 
 	buddy_delete(b);
 	return 0;


### PR DESCRIPTION
fix一个边界条件的bug

当较高粒度位置的结点整个被分配，left == -1时，再分配低粒度的结点有可能引发 index=-1被传入。
